### PR TITLE
revert to use Merged Info on createProfile

### DIFF
--- a/authStore.go
+++ b/authStore.go
@@ -499,10 +499,10 @@ func (s *authStore) CreateProfile(w http.ResponseWriter, r *http.Request) (*Logi
 	}
 	b := s.b.Clone()
 	defer b.Close()
-	return s.createProfile(w, r, b, csrfToken, profile.Password)
+	return s.createProfile(w, r, b, csrfToken, *profile)
 }
 
-func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Backender, csrfToken, password string) (*LoginSession, error) {
+func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Backender, csrfToken string, userProfile profile) (*LoginSession, error) {
 	emailCookie, err := s.getEmailCookie(w, r)
 	if err != nil || emailCookie.EmailVerificationCode == "" {
 		return nil, newLoggedError("Unable to get email verification cookie", err)
@@ -520,8 +520,12 @@ func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Back
 	if session.CSRFToken != csrfToken {
 		return nil, errInvalidCSRF
 	}
+	mergedInfo := session.Info
+	for key, value := range userProfile.Info {
+		mergedInfo[key] = value
+	}
 
-	err = b.UpdateUser(session.UserID, password, session.Info)
+	err = b.UpdateUser(session.UserID, userProfile.Password, mergedInfo)
 	if err != nil {
 		return nil, newLoggedError("Unable to update user", err)
 	}
@@ -531,7 +535,7 @@ func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Back
 		return nil, newLoggedError("Error while creating profile", err)
 	}
 
-	ls, err := s.createSession(w, r, b, session.UserID, session.Email, session.Info, false)
+	ls, err := s.createSession(w, r, b, session.UserID, session.Email, mergedInfo, false)
 	if err != nil {
 		return nil, err
 	}

--- a/authStore.go
+++ b/authStore.go
@@ -499,10 +499,10 @@ func (s *authStore) CreateProfile(w http.ResponseWriter, r *http.Request) (*Logi
 	}
 	b := s.b.Clone()
 	defer b.Close()
-	return s.createProfile(w, r, b, csrfToken, *profile)
+	return s.createProfile(w, r, b, csrfToken, profile)
 }
 
-func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Backender, csrfToken string, userProfile profile) (*LoginSession, error) {
+func (s *authStore) createProfile(w http.ResponseWriter, r *http.Request, b Backender, csrfToken string, userProfile *profile) (*LoginSession, error) {
 	emailCookie, err := s.getEmailCookie(w, r)
 	if err != nil || emailCookie.EmailVerificationCode == "" {
 		return nil, newLoggedError("Unable to get email verification cookie", err)

--- a/authStore_e2e_test.go
+++ b/authStore_e2e_test.go
@@ -158,7 +158,7 @@ func _createProfile(fullName, password string, emailCookie *emailCookie, b *back
 	r := &http.Request{Header: http.Header{}}
 	c := NewMockCookieStore(map[string]interface{}{"Email": emailCookie}, false, false)
 	s := &authStore{b, m, c}
-
+	p := profile{Password: password}
 	emailVerifyHash, _ := decodeStringToHash(emailCookie.EmailVerificationCode)
 	oldEmailSession := b.getEmailSessionByEmailVerifyHash(emailVerifyHash)
 	var user *user
@@ -167,7 +167,7 @@ func _createProfile(fullName, password string, emailCookie *emailCookie, b *back
 	}
 
 	// create profile
-	newSession, err := s.createProfile(nil, r, b, csrfToken, password)
+	newSession, err := s.createProfile(nil, r, b, csrfToken, &p)
 	if err != nil {
 		return "", nil, err
 	}

--- a/authStore_test.go
+++ b/authStore_test.go
@@ -534,7 +534,7 @@ func TestAuthCreateProfile(t *testing.T) {
 	for i, test := range createProfileTests {
 		backend := &mockBackend{UpdateUserErr: test.UpdateUserErr, getEmailSessionReturn: test.getEmailSessionReturn, CreateSessionReturn: test.CreateSessionReturn, DeleteEmailSessionErr: test.DeleteEmailSessionErr}
 		store := getAuthStore(test.EmailCookie, nil, nil, test.HasCookieGetError, test.HasCookiePutError, nil, backend)
-		_, err := store.createProfile(nil, &http.Request{}, backend, test.CSRFToken, "password")
+		_, err := store.createProfile(nil, &http.Request{}, backend, test.CSRFToken, &profile{Password: "password"})
 		methods := store.b.(*mockBackend).MethodsCalled
 		if (err == nil && test.ExpectedErr != "" || err != nil && test.ExpectedErr != err.Error()) ||
 			!collectionEqual(test.MethodsCalled, methods) {


### PR DESCRIPTION
This should restore the functionality of actually saving a user's name

And it looks like I broke it back in the day after-all :(