### PR TITLE
SameSite=None cookie header

### DIFF
--- a/cookieStore.go
+++ b/cookieStore.go
@@ -74,6 +74,11 @@ func (s *cookieStore) Delete(w http.ResponseWriter, key string) {
 }
 
 func newCookie(name string, value string, domain string, secureOnly bool, expireMins int) *http.Cookie {
+	sameSite := http.SameSiteLaxMode
+	if secureOnly {
+			sameSite = http.SameSiteNoneMode
+	}
+
 	return &http.Cookie{
 		Expires:  time.Now().UTC().Add(time.Duration(expireMins) * time.Minute),
 		Name:     name,
@@ -82,6 +87,7 @@ func newCookie(name string, value string, domain string, secureOnly bool, expire
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   secureOnly,
+		SameSite: sameSite,
 		MaxAge:   expireMins * 60, // time in seconds
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/6degreeshealth/auth
+module github.com/EndFirstCorp/auth
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/EndFirstCorp/auth
+module github.com/6degreeshealth/auth
 
 go 1.12
 


### PR DESCRIPTION
This allows users who have the Chrome security upgrade of July, 2020 to continue to access cross-origin cookies.